### PR TITLE
tls: make sure certificates can't be read by other users

### DIFF
--- a/pingoo/error.rs
+++ b/pingoo/error.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::net::SocketAddr;
 
 use crate::geoip;
@@ -16,10 +17,18 @@ pub enum Error {
     },
     #[error("{0}")]
     Tls(String),
+    #[error("{0}")]
+    IO(String),
 }
 
 impl From<geoip::Error> for Error {
     fn from(err: geoip::Error) -> Self {
         Error::Unspecified(err.to_string())
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::IO(err.to_string())
     }
 }

--- a/pingoo/tls/tls_manager.rs
+++ b/pingoo/tls/tls_manager.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, os::unix::fs::PermissionsExt, path::PathBuf, sync::Arc};
 
 use dashmap::DashMap;
 use rustls::{
@@ -6,7 +6,7 @@ use rustls::{
     crypto::CryptoProvider,
     server::{ClientHello, ResolvesServerCert},
 };
-use tokio::fs;
+use tokio::fs::{self, set_permissions};
 use tracing::warn;
 
 use crate::{
@@ -54,9 +54,13 @@ impl Debug for AcmeConfig {
 
 impl TlsManager {
     pub async fn new(tls_config: &TlsConfig) -> Result<Self, Error> {
-        fs::create_dir_all(DEFAULT_TLS_FOLDER)
+        let tls_dir: PathBuf = DEFAULT_TLS_FOLDER.into();
+        fs::create_dir_all(&tls_dir)
             .await
             .map_err(|err| Error::Config(format!("error creating TLS folder ({DEFAULT_TLS_FOLDER}): {err}")))?;
+        let mut dir_permissions = tls_dir.metadata()?.permissions();
+        dir_permissions.set_mode(0o750);
+        set_permissions(&tls_dir, dir_permissions).await?;
 
         let (certificates, wildcard_certificates) = load_certificates(DEFAULT_TLS_FOLDER).await?;
 


### PR DESCRIPTION
## Issue
Currently `/etc/pingoo/tls` folder has `drwxr-xr-x` (755) permissions. This is where certificates are stored and they are created with `-rw-r--r--` (644) mode.

## Solution
This change introduces additional security layer which makes sure that certificates can't be read by other linux users, by setting 750 directory mode (`drwxr-x---`) for the `/etc/pingoo/tls` dir