### PR TITLE
services: support http -> https redirect

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,8 @@ services:
     # match any request / connection if left empty
     route: http_request.starts_with("/api")
     http_proxy: [] # list of upstreams. Can be left empty if using Docker service discovery
+    # (optional) force https when service accessed via http
+    https_redirect: true
 
   webapp:
     # static site

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -35,6 +35,11 @@ listeners:
   https:
     address: https://0.0.0.0
 
+services:
+  api:
+    https_redirect: true
+    http_proxy: []
+
 tls:
   acme:
     domains: ["pingoo.io"]

--- a/pingoo/config/config.rs
+++ b/pingoo/config/config.rs
@@ -73,6 +73,7 @@ pub struct ServiceConfig {
     pub http_proxy: Option<Vec<UpstreamConfig>>,
     pub r#static: Option<StaticSiteServiceConfig>,
     pub tcp_proxy: Option<Vec<UpstreamConfig>>,
+    pub https_redirect: Option<bool>,
 }
 
 // #[derive(Clone, Debug)]

--- a/pingoo/config/config_file.rs
+++ b/pingoo/config/config_file.rs
@@ -62,6 +62,7 @@ pub struct ServiceConfigFile {
     pub tcp_proxy: Option<Vec<String>>,
     // #[serde(default)]
     // pub rules: Vec<String>,
+    pub https_redirect: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -264,12 +265,15 @@ pub fn parse_service(service_name: String, service: ServiceConfigFile) -> Result
         .unwrap_or(Ok(None))
         .map_err(|err: rules::Error| Error::Config(format!("error parsing route for service {service_name}: {err}")))?;
 
+    let https_redirect = service.https_redirect;
+
     return Ok(ServiceConfig {
         name: service_name,
         route,
         http_proxy,
         r#static: r#static,
         tcp_proxy,
+        https_redirect,
     });
 }
 

--- a/pingoo/listeners/http_listener.rs
+++ b/pingoo/listeners/http_listener.rs
@@ -2,7 +2,6 @@ use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
 use ::rules::Action;
 use cookie::Cookie;
-use http::Request;
 use hyper::service::service_fn;
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
@@ -21,8 +20,8 @@ use crate::{
     services::{
         HttpService,
         http_utils::{
-            HOSTNAME_MAX_LENGTH, RequestContext, RequestExtensionContext, USER_AGENT_MAX_LENGTH, get_path,
-            new_blocked_response, new_not_found_error,
+            RequestContext, RequestExtensionContext, USER_AGENT_MAX_LENGTH, get_host, get_path, new_blocked_response,
+            new_not_found_error,
         },
     },
 };
@@ -279,18 +278,4 @@ pub(super) async fn serve_http_requests<IO: hyper::rt::Read + hyper::rt::Write +
     {
         error!(listener = listener_name.as_ref(), "error serving HTTP connection: {err:?}");
     };
-}
-
-pub fn get_host(req: &Request<hyper::body::Incoming>) -> heapless::String<HOSTNAME_MAX_LENGTH> {
-    // uri.host is present for HTTP/2 requests
-    if let Some(host) = req.uri().host() {
-        return heapless::String::from_str(host.trim()).unwrap_or_default();
-    }
-
-    // otherwise, in HTTP/1.x it should be present in the Host header
-    if let Some(host) = req.headers().get(http::header::HOST) {
-        return heapless::String::from_str(host.to_str().unwrap_or_default().trim()).unwrap_or_default();
-    }
-
-    return heapless::String::new();
 }

--- a/pingoo/services/http_proxy_service.rs
+++ b/pingoo/services/http_proxy_service.rs
@@ -16,7 +16,7 @@ use crate::{
     service_discovery::service_registry::ServiceRegistry,
     services::{
         HttpService,
-        http_utils::{RequestExtensionContext, new_bad_gateway_error},
+        http_utils::{RequestExtensionContext, new_bad_gateway_error, new_https_redirect_response},
     },
 };
 
@@ -47,6 +47,7 @@ pub struct HttpProxyService {
     http_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     service_registry: Arc<ServiceRegistry>,
     route: Option<rules::CompiledExpression>,
+    https_redirect: bool,
 }
 
 impl HttpProxyService {
@@ -75,6 +76,7 @@ impl HttpProxyService {
             http_client,
             service_registry,
             route: config.route,
+            https_redirect: config.https_redirect.unwrap_or(false),
         };
     }
 }
@@ -98,6 +100,10 @@ impl HttpService for HttpProxyService {
         &self,
         mut req: Request<hyper::body::Incoming>,
     ) -> Response<BoxBody<Bytes, hyper::Error>> {
+        if self.https_redirect {
+            return new_https_redirect_response(&req);
+        }
+
         let upstreams = self.service_registry.get_upstreams(&self.name).await;
         if upstreams.is_empty() {
             debug!("[{}]: no upstream available", self.name);

--- a/pingoo/services/http_static_site_service.rs
+++ b/pingoo/services/http_static_site_service.rs
@@ -22,7 +22,8 @@ use crate::{
     services::{
         HttpService,
         http_utils::{
-            CACHE_CONTROL_DYNAMIC, new_internal_error_response_500, new_method_not_allowed_error, new_not_found_error,
+            CACHE_CONTROL_DYNAMIC, new_https_redirect_response, new_internal_error_response_500,
+            new_method_not_allowed_error, new_not_found_error,
         },
     },
 };
@@ -37,6 +38,7 @@ pub struct StaticSiteService {
     config: StaticSiteServiceConfig,
     /// in-memory cache for popular files
     cache: Cache<PathBuf, Arc<CachedFile>>,
+    https_redirect: bool,
 }
 
 #[derive(Clone)]
@@ -61,6 +63,7 @@ impl StaticSiteService {
             route: config.route,
             name: Arc::new(config.name),
             cache,
+            https_redirect: config.https_redirect.unwrap_or(false),
         };
     }
 }
@@ -81,6 +84,9 @@ impl HttpService for StaticSiteService {
     }
 
     async fn handle_http_request(&self, req: Request<hyper::body::Incoming>) -> Response<BoxBody<Bytes, hyper::Error>> {
+        if self.https_redirect {
+            return new_https_redirect_response(&req);
+        }
         let url_path = req.uri().path().trim_start_matches('/').trim_end_matches('/').trim();
 
         if req.method() != Method::GET && req.method() != Method::HEAD {

--- a/pingoo/services/http_utils.rs
+++ b/pingoo/services/http_utils.rs
@@ -1,7 +1,7 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
 use bytes::Bytes;
-use http::{HeaderValue, Request, Response, StatusCode, header};
+use http::{HeaderValue, Request, Response, StatusCode, Uri, header};
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::body::Incoming;
 use serde::Serialize;
@@ -109,6 +109,50 @@ pub fn new_method_not_allowed_error() -> Response<BoxBody<Bytes, hyper::Error>> 
         .header(header::CACHE_CONTROL, &CACHE_CONTROL_NO_CACHE)
         .body(res_body)
         .expect("error building new_method_not_allowed_error");
+}
+
+pub fn new_https_redirect_response(req: &Request<hyper::body::Incoming>) -> Response<BoxBody<Bytes, hyper::Error>> {
+    let authority = get_host(req);
+    let uri_builder = Uri::builder().scheme("https").authority(authority.as_str());
+
+    let redirect_uri = match req.uri().path_and_query() {
+        Some(pg) => uri_builder
+            .path_and_query(pg.as_str())
+            .build()
+            .expect("https redirect URI should be valid"),
+        None => uri_builder.build().expect("https redirect URI should be valid"),
+    };
+
+    let res_body = Full::new(Bytes::from_static(b""))
+        .map_err(|never| match never {})
+        .boxed();
+    return Response::builder()
+        .status(StatusCode::PERMANENT_REDIRECT)
+        .header(header::LOCATION, redirect_uri.to_string())
+        .body(res_body)
+        .expect("error building new_https_redirect_response");
+}
+
+pub fn get_host(req: &Request<hyper::body::Incoming>) -> heapless::String<HOSTNAME_MAX_LENGTH> {
+    // uri.host is present for HTTP/2 requests
+    // contrary to Host header it doesn't contain port
+    if let Some(just_host) = req.uri().host() {
+        // in order to unify the behavior we need to enrich it
+        if let Some(port) = req.uri().port() {
+            let mut host = heapless::String::from_str(port.as_str().trim()).unwrap_or_default();
+            host.insert_str(0, ":").unwrap_or_default();
+            host.insert_str(0, just_host.trim()).unwrap_or_default();
+            return host;
+        }
+        return heapless::String::from_str(just_host.trim()).unwrap_or_default();
+    }
+
+    // otherwise, in HTTP/1.x it should be present in the Host header
+    if let Some(host) = req.headers().get(http::header::HOST) {
+        return heapless::String::from_str(host.to_str().unwrap_or_default().trim()).unwrap_or_default();
+    }
+
+    return heapless::String::new();
 }
 
 pub fn get_path(req: &Request<Incoming>) -> &str {


### PR DESCRIPTION
closes #20

```diff
services:
  api:
    http_proxy: []
+   https_redirect: true
```

## how it was tested
```
curl --http1.1 -i http://localhost:8080/
curl --http2-prior-knowledge -i http://localhost:8080/
```