### PR TITLE
docs: fix route examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,7 @@ services:
   api: # name of the service
     # (optional) expression to filter requests
     # match any request / connection if left empty
-    route: http_request.starts_with("/api")
+    route: http_request.path.starts_with("/api")
     http_proxy: [] # list of upstreams. Can be left empty if using Docker service discovery
 
   webapp:

--- a/docs/services.md
+++ b/docs/services.md
@@ -15,7 +15,7 @@ url: "/docs/services"
 ```yml
 services:
   api:
-    route: host.starts_with("api")
+    route: http_request.host.starts_with("api")
     http_proxy: ["http://127.0.0.1"]
 ```
 
@@ -31,7 +31,7 @@ listeners:
 
 services:
   api:
-    route: host.starts_with("api")
+    route: http_request.host.starts_with("api")
     http_proxy: ["http://api1.myservice.internal", "http://api2.myservice.internal"]
 ```
 


### PR DESCRIPTION
```diff
services:
  api:
-    route: http_request.starts_with("/api")
+    route: http_request.path.starts_with("/api")
    http_proxy: ["http://127.0.0.1:3000"]
```

otherwise pingoo responds with `HTTP 404` and produces this log:
```js
{
  timestamp: '2026-01-30T15:24:02.548805Z',
  level: 'WARN',
  message: `error executing route for service api: Unexpected type: got 'Map(Map { map: {String("method"): String("GET"), String("path"): String("/api/foo"), String("host"): String("foo.tuxnet.dev"), String("url"): String("https://foo.bar/api/foo"), String("user_agent"): String("curl/7.88.1")} })', want 'Arc<String>'`
}
```