### PR TITLE
rules: cidr ip whitelisting

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -82,6 +82,7 @@ Pingoo currently supports the following actions:
 
 - `captcha`: Serve a CAPTCHA to the client that must be solved to proceed.
 - `block`: Serve a 403 permission denied page.
+- `allow`: Serve 403 permission denied page on CIDR mismatch
 
 
 ## Lists
@@ -118,3 +119,15 @@ Valid lists types:
 - `String`
 - `Ip`
 
+## CIDR whitelist
+Instead of lists you can define `cidr_v4` or `cidr_v6` together with `allow`
+action.
+```yml
+rules:
+  restrict_internal_routes:
+    cidr_v4: 10.2.0.0/16
+    expression: |
+      http_request.host == "api.bar.private"
+    actions:
+      - action: allow
+```

--- a/pingoo/config/config.rs
+++ b/pingoo/config/config.rs
@@ -258,8 +258,7 @@ pub async fn load_and_validate() -> Result<Config, Error> {
         .map(|(rule_name, rule_config)| {
             let mut cidr_v4: Option<CidrV4> = None;
             if let Some(c4) = rule_config.cidr_v4 {
-                let c4 = load_cidr_v4(c4)?;
-                cidr_v4 = Some(c4);
+                cidr_v4 = Some(load_cidr_v4(c4)?);
             }
             let mut cidr_v6: Option<CidrV6> = None;
             if let Some(c6) = rule_config.cidr_v6 {

--- a/pingoo/config/config.rs
+++ b/pingoo/config/config.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use std::{
     collections::{HashMap, HashSet},
-    net::SocketAddr,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     path::PathBuf,
     str::FromStr,
 };
@@ -16,7 +16,7 @@ use crate::{
     Error,
     config::config_file::{ConfigFile, RuleConfigFile, parse_service},
     lists::ListType,
-    rules::Rule,
+    rules::{CidrV4, CidrV6, Rule},
     service_discovery::service_registry::Upstream,
     tls::acme::LETSENCRYPT_PRODUCTION_URL,
 };
@@ -256,6 +256,16 @@ pub async fn load_and_validate() -> Result<Config, Error> {
         .rules
         .into_iter()
         .map(|(rule_name, rule_config)| {
+            let mut cidr_v4: Option<CidrV4> = None;
+            if let Some(c4) = rule_config.cidr_v4 {
+                let c4 = load_cidr_v4(c4)?;
+                cidr_v4 = Some(c4);
+            }
+            let mut cidr_v6: Option<CidrV6> = None;
+            if let Some(c6) = rule_config.cidr_v6 {
+                cidr_v6 = Some(load_cidr_v6(c6)?);
+            }
+
             Ok(Rule {
                 name: rule_name,
                 expression: rule_config
@@ -263,7 +273,8 @@ pub async fn load_and_validate() -> Result<Config, Error> {
                     .map(|expression| rules::compile_expression(&expression))
                     .map_or(Ok(None), |r| r.map(Some))?,
                 actions: rule_config.actions,
-                cidr: rule_config.cidr,
+                cidr_v4,
+                cidr_v6,
             })
         })
         .collect::<Result<_, rules::Error>>()
@@ -448,4 +459,31 @@ fn default_docker_socket() -> String {
 
 fn default_tls_acme_directory_url() -> String {
     return LETSENCRYPT_PRODUCTION_URL.to_string();
+}
+
+fn load_cidr_v4(cidr: String) -> Result<CidrV4, rules::Error> {
+    let (network, prefix) = split_cidr(cidr)?;
+    let network = Ipv4Addr::from_str(network.as_str())?;
+    let prefix = prefix.parse::<u32>()?;
+
+    Ok(CidrV4::new(network, prefix))
+}
+
+fn load_cidr_v6(cidr: String) -> Result<CidrV6, rules::Error> {
+    let (network, prefix) = split_cidr(cidr)?;
+    let network = Ipv6Addr::from_str(network.as_str())?;
+    let prefix = prefix.parse::<u128>()?;
+
+    Ok(CidrV6::new(network, prefix))
+}
+
+fn split_cidr(cidr: String) -> Result<(String, String), rules::Error> {
+    let c: Vec<&str> = cidr.split("/").collect();
+    if c.len() != 2 {
+        return Err(rules::Error::InvalidCidrFormatError(cidr));
+    }
+    let network = c[0];
+    let prefix = c[1];
+
+    Ok((network.into(), prefix.into()))
 }

--- a/pingoo/config/config.rs
+++ b/pingoo/config/config.rs
@@ -263,6 +263,7 @@ pub async fn load_and_validate() -> Result<Config, Error> {
                     .map(|expression| rules::compile_expression(&expression))
                     .map_or(Ok(None), |r| r.map(Some))?,
                 actions: rule_config.actions,
+                cidr: rule_config.cidr,
             })
         })
         .collect::<Result<_, rules::Error>>()

--- a/pingoo/config/config_file.rs
+++ b/pingoo/config/config_file.rs
@@ -98,7 +98,8 @@ pub struct ServiceConfigFileStaticNotFound {
 pub struct RuleConfigFile {
     pub expression: Option<String>,
     pub actions: Vec<rules::Action>,
-    pub cidr: Option<String>,
+    pub cidr_v4: Option<String>,
+    pub cidr_v6: Option<String>,
 }
 
 impl Default for ServiceConfigFileStaticNotFound {

--- a/pingoo/config/config_file.rs
+++ b/pingoo/config/config_file.rs
@@ -98,6 +98,7 @@ pub struct ServiceConfigFileStaticNotFound {
 pub struct RuleConfigFile {
     pub expression: Option<String>,
     pub actions: Vec<rules::Action>,
+    pub cidr: Option<String>,
 }
 
 impl Default for ServiceConfigFileStaticNotFound {

--- a/pingoo/listeners/http_listener.rs
+++ b/pingoo/listeners/http_listener.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
@@ -256,6 +256,7 @@ pub(super) async fn serve_http_requests<IO: hyper::rt::Read + hyper::rt::Write +
                 if rule.match_request(&rules_ctx) {
                     for action in &rule.actions {
                         match action {
+                            // todo: cidr support in other actions
                             Action::Block {} => return Ok(new_blocked_response()),
                             Action::Captcha {} => {
                                 if !captcha_verified {
@@ -263,27 +264,29 @@ pub(super) async fn serve_http_requests<IO: hyper::rt::Read + hyper::rt::Write +
                                 }
                             }
                             Action::Allow {} => {
-                                if let Some(cidr) = &rule.cidr {
-                                    let c: Vec<&str> = cidr.split("/").collect();
-                                    if c.len() != 2 {
-                                        return Ok(new_blocked_response());
-                                    }
-                                    let network = c[0];
-                                    let prefix = c[1];
-
+                                if let Some(cidr) = &rule.cidr_v4 {
                                     match client_data.ip {
                                         IpAddr::V4(ip) => {
-                                            if !is_cidr_v4_match(ip, network, prefix) {
+                                            if !cidr.contains(ip) {
                                                 return Ok(new_blocked_response());
                                             }
                                         }
-                                        IpAddr::V6(ip) => {
-                                            if !is_cidr_v6_match(ip, network, prefix) {
-                                                return Ok(new_blocked_response());
-                                            }
-                                        }
+                                        IpAddr::V6(_) => {}
                                     }
                                 }
+
+                                if let Some(cidr) = &rule.cidr_v6 {
+                                    match client_data.ip {
+                                        IpAddr::V6(ip) => {
+                                            if !cidr.contains(ip) {
+                                                return Ok(new_blocked_response());
+                                            }
+                                        }
+                                        IpAddr::V4(_) => {}
+                                    }
+                                }
+
+                                // otherwise just pass through
                             }
                         }
                     }
@@ -320,24 +323,4 @@ pub fn get_host(req: &Request<hyper::body::Incoming>) -> heapless::String<HOSTNA
     }
 
     return heapless::String::new();
-}
-
-fn is_cidr_v4_match(client_ip: Ipv4Addr, network: &str, prefix: &str) -> bool {
-    if let Ok(network) = Ipv4Addr::from_str(network) {
-        if let Ok(prefix) = prefix.parse::<u32>() {
-            let mask = if prefix == 0 { 0 } else { u32::MAX << (32 - prefix) };
-            return (client_ip.to_bits() & mask) == (network.to_bits() & mask);
-        }
-    }
-    false
-}
-
-fn is_cidr_v6_match(client_ip: Ipv6Addr, network: &str, prefix: &str) -> bool {
-    if let Ok(network) = Ipv6Addr::from_str(network) {
-        if let Ok(prefix) = prefix.parse::<u128>() {
-            let mask = if prefix == 0 { 0 } else { u128::MAX << (128 - prefix) };
-            return (client_ip.to_bits() & mask) == (network.to_bits() & mask);
-        }
-    }
-    false
 }

--- a/pingoo/listeners/http_listener.rs
+++ b/pingoo/listeners/http_listener.rs
@@ -1,4 +1,8 @@
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
+};
 
 use ::rules::Action;
 use cookie::Cookie;
@@ -258,6 +262,29 @@ pub(super) async fn serve_http_requests<IO: hyper::rt::Read + hyper::rt::Write +
                                     return Ok(captcha_manager.serve_captcha());
                                 }
                             }
+                            Action::Allow {} => {
+                                if let Some(cidr) = &rule.cidr {
+                                    let c: Vec<&str> = cidr.split("/").collect();
+                                    if c.len() != 2 {
+                                        return Ok(new_blocked_response());
+                                    }
+                                    let network = c[0];
+                                    let prefix = c[1];
+
+                                    match client_data.ip {
+                                        IpAddr::V4(ip) => {
+                                            if !is_cidr_v4_match(ip, network, prefix) {
+                                                return Ok(new_blocked_response());
+                                            }
+                                        }
+                                        IpAddr::V6(ip) => {
+                                            if !is_cidr_v6_match(ip, network, prefix) {
+                                                return Ok(new_blocked_response());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -293,4 +320,24 @@ pub fn get_host(req: &Request<hyper::body::Incoming>) -> heapless::String<HOSTNA
     }
 
     return heapless::String::new();
+}
+
+fn is_cidr_v4_match(client_ip: Ipv4Addr, network: &str, prefix: &str) -> bool {
+    if let Ok(network) = Ipv4Addr::from_str(network) {
+        if let Ok(prefix) = prefix.parse::<u32>() {
+            let mask = if prefix == 0 { 0 } else { u32::MAX << (32 - prefix) };
+            return (client_ip.to_bits() & mask) == (network.to_bits() & mask);
+        }
+    }
+    false
+}
+
+fn is_cidr_v6_match(client_ip: Ipv6Addr, network: &str, prefix: &str) -> bool {
+    if let Ok(network) = Ipv6Addr::from_str(network) {
+        if let Ok(prefix) = prefix.parse::<u128>() {
+            let mask = if prefix == 0 { 0 } else { u128::MAX << (128 - prefix) };
+            return (client_ip.to_bits() & mask) == (network.to_bits() & mask);
+        }
+    }
+    false
 }

--- a/pingoo/rules.rs
+++ b/pingoo/rules.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use http::Uri;
 use serde::Serialize;
@@ -11,7 +11,8 @@ pub struct Rule {
     pub name: String,
     pub expression: Option<rules::CompiledExpression>,
     pub actions: Vec<rules::Action>,
-    pub cidr: Option<String>,
+    pub cidr_v4: Option<CidrV4>,
+    pub cidr_v6: Option<CidrV6>,
 }
 
 #[derive(Debug, Serialize)]
@@ -58,3 +59,39 @@ impl Rule {
 // {
 //     serializer.serialize_str(value)
 // }
+
+#[derive(Debug, Clone)]
+pub struct CidrV4 {
+    pub network: Ipv4Addr,
+    pub prefix: u32,
+    mask: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct CidrV6 {
+    pub network: Ipv6Addr,
+    pub prefix: u128,
+    mask: u128,
+}
+
+impl CidrV4 {
+    pub fn new(network: Ipv4Addr, prefix: u32) -> Self {
+        let mask = if prefix == 0 { 0 } else { u32::MAX << (32 - prefix) };
+        Self { network, prefix, mask }
+    }
+
+    pub fn contains(&self, ip: Ipv4Addr) -> bool {
+        (ip.to_bits() & self.mask) == (self.network.to_bits() & self.mask)
+    }
+}
+
+impl CidrV6 {
+    pub fn new(network: Ipv6Addr, prefix: u128) -> Self {
+        let mask = if prefix == 0 { 0 } else { u128::MAX << (128 - prefix) };
+        Self { network, prefix, mask }
+    }
+
+    pub fn contains(&self, ip: Ipv6Addr) -> bool {
+        (ip.to_bits() & self.mask) == (self.network.to_bits() & self.mask)
+    }
+}

--- a/pingoo/rules.rs
+++ b/pingoo/rules.rs
@@ -11,6 +11,7 @@ pub struct Rule {
     pub name: String,
     pub expression: Option<rules::CompiledExpression>,
     pub actions: Vec<rules::Action>,
+    pub cidr: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/rules/rules.rs
+++ b/rules/rules.rs
@@ -32,6 +32,7 @@ pub type Context<'a> = bel::Context<'a>;
 pub enum Action {
     Block {},
     Captcha {},
+    Allow {},
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/rules/rules.rs
+++ b/rules/rules.rs
@@ -41,6 +41,12 @@ pub enum Error {
     Unspecified(String),
     #[error("Expression is not valid: {0}")]
     ExpressionIsNotValid(String),
+    #[error("{0}")]
+    ParseIntError(String),
+    #[error("{0}")]
+    AddrParseError(String),
+    #[error("invalid CIDR format, expected <network>/<prefix>, got: {0}")]
+    InvalidCidrFormatError(String),
 }
 
 pub fn compile_expression(expression: &str) -> Result<CompiledExpression, Error> {
@@ -75,4 +81,16 @@ pub fn validate_expression(expression: &str) -> Result<(), Error> {
     // TODO
 
     return Ok(());
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(err: std::num::ParseIntError) -> Self {
+        Error::ParseIntError(err.to_string())
+    }
+}
+
+impl From<std::net::AddrParseError> for Error {
+    fn from(err: std::net::AddrParseError) -> Self {
+        Error::AddrParseError(err.to_string())
+    }
 }


### PR DESCRIPTION
closes issue #28

## use case
As a user I want to restrict specific services only to VPN IPs, w/o relying only on DNS resolutions so that attackers can't bypass with
```console
curl -i -k https://api.foo.com -H "host: api.bar.private"
```

## pain point
Biggest friction is that for IP addresses for range 10.2.0.0/16 I need to generate `/etc/pingoo/allowed_ips.csv` which contains 65536 lines that occupies additional memory instead of providing one line with CIDR

## changes summary
new `rules` features:
* `allow` action
* `cidr_v4` property
* `cidr_v6` property

```diff
listeners:
  https:
    address: https://0.0.0.0
    services:
      - public
      - private

tls:
  acme:
    domains:
      - "api.foo.com"

services:
  public:
    route: |
      http_request.host == "api.foo.com"
    http_proxy: ["http://127.0.0.1:3000"]
  private:
    route: |
      http_request.host == "api.bar.private"
    http_proxy: ["http://127.0.0.1:3001"]

rules:
  restrict_internal_routes:
+    cidr_v4: 10.2.0.0/16
    expression: |
      http_request.host == "api.bar.private"
    actions:
+      - action: allow
```